### PR TITLE
Fixed update json

### DIFF
--- a/YT-Update.json
+++ b/YT-Update.json
@@ -1,6 +1,6 @@
 {
   "version": "v18.08.39",
   "versionCode": 1536294336,
-  "zipUrl": "https://github.com/RabahX/YT-ReVanced-Module/releases/download/v18.08.39/YT-Module-ReVanced.zip",
+  "zipUrl": "https://github.com/RabahX/YT-ReVanced-Module/releases/download/v18.08.39/YT-ReVanced-Module.zip",
   "changelog": "https://raw.githubusercontent.com/RabahX/YT-ReVanced-Module/main/Changelog.md"
  }


### PR DESCRIPTION
Fixed a typo in YT-Update.json that causes ota update from Magisk to fail